### PR TITLE
Remove gatsby-matomo-plugin, since tag manager inits matomo in seo.js

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -108,14 +108,6 @@ module.exports = {
       },
     },
     {
-      resolve: "gatsby-plugin-matomo",
-      options: {
-        siteId: 1,
-        matomoUrl: "https://skynetlabs.matomo.cloud",
-        siteUrl: "https://skynetlabs.com",
-      },
-    },
-    {
       resolve: "gatsby-plugin-sitemap",
       options: {
         output: "/",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "gatsby-background-image": "1.6.0",
     "gatsby-plugin-image": "2.7.0",
     "gatsby-plugin-manifest": "4.7.0",
-    "gatsby-plugin-matomo": "0.11.0",
     "gatsby-plugin-postcss": "5.7.0",
     "gatsby-plugin-purgecss": "6.1.0",
     "gatsby-plugin-react-helmet": "5.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5654,11 +5654,6 @@ gatsby-plugin-manifest@4.7.0:
     semver "^7.3.5"
     sharp "^0.29.3"
 
-gatsby-plugin-matomo@0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-matomo/-/gatsby-plugin-matomo-0.11.0.tgz#2a4322df78045af0b3f44ba7b8c455d57b526f96"
-  integrity sha512-yvQFOGky3vyEEmmtopDvsrlnZ8htYrgHHD9CCvlFQ6DrGSL+Y01wkbJZBMpiGAiRt/GKh/8MGWcMfSAGoMQM9g==
-
 gatsby-plugin-page-creator@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-4.7.0.tgz#7139b6fc8d61dfccffb68fdb7221a2713d2bc5a7"


### PR DESCRIPTION
# PULL REQUEST

## Overview
Current settings double-load matomo js code, causing two events (and slowing load time)

Since tag manager bundle is also set to load the code, we can remove the matomo plugin for gatsby. All configuration is now in the Matomo Tag Manager backend.
